### PR TITLE
🖼️ Typo inside cursor preview fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- `Turqouise` typo fixed #9 (by @yochananmarqos)
+
 ## [v1.0.0] - 5 Apr 2021
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ Bibata Extra is a fork of [Bibata](https://github.com/ful1e5/Bibata_Cursor) for 
 </p>
 
 <p align="center">
-  <img title="Bibata Pink" width="90%" src="https://i.postimg.cc/FRFPsymD/Pink.png">
+  <img title="Bibata Pink" width="90%" src="https://i.postimg.cc/j5hF0ygp/Pink.png">
   </br>
   <sub>Bibata Pink</sub>
 </p>
 
 <p align="center">
-  <img title="Bibata Turquoise" width="90%" src="https://i.postimg.cc/brs31qZn/Turquoise.png">
+  <img title="Bibata Turquoise" width="90%" src="https://i.postimg.cc/PJ3VNTkK/Turquoise.png">
   </br>
   <sub>Bibata Turquoise</sub>
 </p>


### PR DESCRIPTION
### Changed
- Fix the `Turquoise` typo inside [README.md](./README.md#preview) cursors preview.
- Update `CHANGELOG.md` unreleased with #9